### PR TITLE
Fix header fallback test

### DIFF
--- a/app/_layout/header/Header.test.tsx
+++ b/app/_layout/header/Header.test.tsx
@@ -1,10 +1,34 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import Header from "./Header";
+import React from "react";
 
 // Mock the Logo and NavBar components
-jest.mock("@/components/navbar/NavBar", () => () => (
-  <nav data-testid="navbar" />
-));
+let resolveNavBar: () => void;
+let navBarPromise: Promise<{ default: React.FC }>;
+let isResolved = false;
+
+jest.mock("@/components/navbar/NavBar", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: () => {
+      if (!isResolved) {
+        throw navBarPromise;
+      }
+      return <nav data-testid="navbar" />;
+    },
+  };
+});
+
+beforeEach(() => {
+  isResolved = false;
+  navBarPromise = new Promise<{ default: React.FC }>((resolve) => {
+    resolveNavBar = () => {
+      isResolved = true;
+      resolve({ default: () => <nav data-testid="navbar" /> });
+    };
+  });
+});
 jest.mock("@/components/logo/Logo", () => () => <div data-testid="logo" />);
 
 describe("Header Component", () => {
@@ -19,17 +43,29 @@ describe("Header Component", () => {
   describe("NavBar", () => {
     it("should render the NavBar component inside Suspense", async () => {
       render(<Header />);
+
+      await act(async () => {
+        resolveNavBar();
+      });
+
       const navbar = await screen.findByTestId("navbar");
       expect(navbar).toBeInTheDocument();
     });
 
-    it("should show fallback content while NavBar is loading", () => {
-      const { container } = render(<Header />);
+    it("should show fallback content while NavBar is loading", async () => {
+      render(<Header />);
 
-      waitFor(() => {
-        const fallback = container.querySelector("div");
-        expect(fallback).toHaveTextContent("Loading navigation...");
+      await waitFor(() => {
+        const fallback = screen.getByText("Loading navigation...");
+        expect(fallback).toBeInTheDocument();
       });
+
+      await act(async () => {
+        resolveNavBar();
+      });
+
+      const navbar = await screen.findByTestId("navbar");
+      expect(navbar).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- mock NavBar lazily so the Suspense fallback appears
- mark header fallback test `async` and wait for the fallback text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843ed27338c8333b0a44ad7c4f7e88c